### PR TITLE
Tell search engines not to index deleted/spam articles, nor to follow their links

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -512,7 +512,7 @@ class LinkInfoPage(Reddit):
         
         # hide deleted/spam links from search engines
         if link._spam or link._deleted:
-            self.robots = 'noindex'
+            self.robots = 'noindex,nofollow'
         
         # TODO: temp hack until we find place for builder_wrapper
         from r2.controllers.listingcontroller import ListingController


### PR DESCRIPTION
The robots string for comment permalinks is overwritten with 'noindex', so if we start getting comment spam another change to put 'nofollow' in might be necessary.
