### PR TITLE
Addressing issue 280, meaningless descriptions for posts when shared on G+

### DIFF
--- a/r2/r2/templates/link.html
+++ b/r2/r2/templates/link.html
@@ -48,8 +48,8 @@
   fullname = thing._fullname
 %>
 
-<div id="thingrow_${fullname}" class="${css_class}">
-  <h${heading_size}><a href="${thing.url}">${self.title()}</a>${unsafe(self.draft())}</h${heading_size}>
+<div id="thingrow_${fullname}" class="${css_class}" itemscope itemtype="http://schema.org/BlogPosting">
+  <h${heading_size} itemprop="name"><a href="${thing.url}">${self.title()}</a>${unsafe(self.draft())}</h${heading_size}>
   <div class="meta clear">
 
     %if thing.hide_score:
@@ -71,7 +71,7 @@
 ##}_RL
   <div id="entry_${fullname}" class="content clear">
 ## The div below is a hack to get the space compressor to leave whitespace in articles alone
-    <div class="md">
+    <div class="md" itemprop="description">
       %if full_article:
         ${self.article()}
       %else:


### PR DESCRIPTION
Issue 280: http://code.google.com/p/lesswrong/issues/detail?id=280

This patch adds schema.org attributes to the title and article text elements on post pages.  According to [Google's snippet FAQ](https://developers.google.com/+/plugins/+1button/#plus-snippet) that's the first place they check to get the text for their link descriptions, and it's easy for us to support.

To test, you can verify that Google can parse out the data correctly using [this tool they provide](http://www.google.com/webmasters/tools/richsnippets) -- I did so and everything seems in order (it identified the name and description.)

Disclaimer:  I don't personally know much about how this may affect SEO or link display on other services, but it seems like the generally recommended way to do things, so I would tend to be optimistic about it.
