### PR TITLE
Change default sort order to newest first (fixes issue 281)

### DIFF
--- a/r2/r2/lib/menus.py
+++ b/r2/r2/lib/menus.py
@@ -550,7 +550,7 @@ class SubredditMenu(NavMenu):
 class TagSortMenu(SimpleGetMenu):
     """Menu for listings by tag"""
     get_param = 'sort'
-    default   = 'old'
+    default   = 'new'
     options   = ('old', 'new', 'top')
 
     def __init__(self, **kw):


### PR DESCRIPTION
Fix for issue 281.

The issue seemed to apply to more than just the RSS feeds mentioned in the issue, as shown in this screenshot - http://imgur.com/f8RSc

Since the issue had a wide scope, this is a global change of the default order for all views from oldest-first to newest-first. If there are any views that require oldest-first ordering that would break from this, I can write a more focused fix.

EDIT: I meant to say issue 281, not 183. I'm not entirely sure where that 183 came from, sorry.
