### PR TITLE
Hide post/comment author labels from the UI

### DIFF
--- a/r2/r2/public/static/main.css
+++ b/r2/r2/public/static/main.css
@@ -107,6 +107,11 @@ h2 a:visited {
 div.tools a {
 	color: #8a8a8b;
 }
+.hide-text {
+    position: absolute;
+    width: 0;
+    overflow: hidden;
+}
 
 
 /* Forms
@@ -311,7 +316,7 @@ div.meta {
 	line-height: 22px;
 	margin: 0 0 12px;
 }
-div.meta span {
+div.meta > span {
 	display: block;
 	float: left;
 	margin-right: 15px;

--- a/r2/r2/templates/comment.html
+++ b/r2/r2/templates/comment.html
@@ -64,7 +64,8 @@ ${parent.collapsed()}
 <% fullname = thing._fullname %>
   %if not thing.deleted:
     <span class="comment-author">
-      Comment author: ${unsafe(self.author(friend=thing.friend, gray = collapse))}
+      <span class="hide-text">Comment author:</span>
+      ${unsafe(self.author(friend=thing.friend, gray = collapse))}
     </span>
   %else:
      <em>${_("Comment deleted")}</em>&#32;

--- a/r2/r2/templates/link.html
+++ b/r2/r2/templates/link.html
@@ -57,7 +57,8 @@
     %else:
       <span class="votes">${self.score(thing, thing.likes, label = False)}</span>
     %endif
-    ${unsafe(self.author(friend = thing.friend, label = "Post author" if full_article else ""))}
+    ${unsafe(self.author(friend = thing.friend,
+                         label = unsafe('<span class="hide-text">Post author:</span>') if full_article else ''))}
     <span class="date">${prettytime(thing._date)}</span>
   </div><!-- .meta -->
 ##{_RL

--- a/r2/r2/templates/printable.html
+++ b/r2/r2/templates/printable.html
@@ -168,7 +168,7 @@ ${self.RenderPrintable()}
     %>
     <span class="${author_cls}">
       %if label:
-        ${label}:
+        ${label}
       %endif
       <a id="author_${thing._fullname}" ${href}>${name}</a>
     </span>


### PR DESCRIPTION
This solves issue 312. The labels are hidden from the UI, and will probably still be visible to Googlebot, depending on how close their crawler is to achieving sentience.
