### PR TITLE
Added a confidence sort order for comments

### DIFF
--- a/r2/r2/lib/db/thing.py
+++ b/r2/r2/lib/db/thing.py
@@ -440,6 +440,10 @@ class Thing(DataThing):
     def _controversy(self):
         return sorts.controversy(self._ups, self._downs)
 
+    @property
+    def _confidence(self):
+        return sorts.confidence(self._ups, self._downs)
+
     @classmethod
     def _build(cls, id, bases):
         return cls(bases.ups, bases.downs, bases.date,

--- a/r2/r2/lib/menus.py
+++ b/r2/r2/lib/menus.py
@@ -61,6 +61,7 @@ menu =   MenuHandler(hot          = _('Popular'),
                      more         = _('More'),
                      relevance    = _('Relevance'),
                      controversial  = _('Controversial'),
+                     confidence   = _('Best'),
                      saved        = _('Saved'),
                      recommended  = _('Recommended'),
                      rising       = _('Rising'),
@@ -435,10 +436,13 @@ class SortMenu(SimpleGetMenu):
             return operators.desc('_score')
         elif sort == 'controversial':
             return operators.desc('_controversy')
+        elif sort == 'confidence':
+            return operators.desc('_confidence')
 
 class CommentSortMenu(SortMenu):
     """Sort menu for comments pages"""
-    options   = ('hot', 'new', 'controversial', 'top', 'old')
+    default   = 'confidence'
+    options   = ('hot', 'new', 'controversial', 'top', 'old', 'confidence')
 
 class SearchSortMenu(SortMenu):
     """Sort menu for search pages."""


### PR DESCRIPTION
Issue 302 - the code calls this a confidence sort, and the UI calls it "best" sort. It was pulled more-or-less verbatim from the Reddit source, and this commit sets it as the default sort order for comments.

I tested it on a set of 3 comments - 40 ups/20 downs; 10/1, and 1/0. It seemed to work as expected.

The linked issue mentions making an explanatory post to the site before it goes live - just so that isn't overlooked.
