### PR TITLE
Redirect to moved links

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -128,7 +128,7 @@ class FrontController(RedditController):
             return self.abort404()
 
         if not c.default_sr and c.site._id != article.sr_id:
-            return self.abort404()
+            return self.redirect(article.make_permalink_slow(), 301)
 
         # moderator is either reddit's moderator or an admin
         is_moderator = c.user_is_loggedin and c.site.is_moderator(c.user) or c.user_is_admin


### PR DESCRIPTION
Fixes issue 311. It's a very general solution to the problem - it redirects in all cases to the correct subreddit based on the link ID.
