### PR TITLE
Issue 337 - Possible fix for spurious lock errors

### DIFF
--- a/r2/r2/lib/lock.py
+++ b/r2/r2/lib/lock.py
@@ -33,7 +33,7 @@ class MemcacheLock(object):
     attempt to grab a lock by 'adding' the lock name. If the response
     is True, we have the lock. If it's False, someone else has it."""
 
-    def __init__(self, key, cache, time = 30, timeout = 30):
+    def __init__(self, key, cache, time = 20, timeout = 30):
         self.key = key
         self.cache = cache
         self.time = time


### PR DESCRIPTION
http://code.google.com/p/lesswrong/issues/detail?id=337

My guess is that something is causing the lock keys to not be deleted. So - if we tell memcached to expire the key sooner than the polling timeout period, then even if there's a mistake somewhere and a key isn't deleted, it will right itself after a delay.

So this will only (possibly) fix the symptoms and not the underlying problem, but it's still a quick and easy fix. If this doesn't help I'll probably add generous logging and try to piece things together from that.
