### PR TITLE
Fix a small bug in polling

### DIFF
--- a/r2/r2/models/poll.py
+++ b/r2/r2/models/poll.py
@@ -219,7 +219,6 @@ class NumberPoll(PollType):
         responsenum = float(response)
         poll.sum += responsenum
         responses = [float(ballot.response) for ballot in poll.get_ballots()]
-        responses.append(responsenum)
         responses.sort()
         poll.median = median(responses)
         


### PR DESCRIPTION
In number polls, when computing the median, it would double-count the last vote (adding it to a list thinking it hadn't been added yet, when it had). This patch fixes that.
