### PR TITLE
Make new comments stand out more.

### DIFF
--- a/r2/r2/public/static/main.css
+++ b/r2/r2/public/static/main.css
@@ -631,7 +631,7 @@ div.message div.message div.message div.message div.message div.message div.mess
 }
 .new-comment,
 div.comment div.new-comment {
-    border: 5px solid #dcf8d9 !important;
+    border: 5px solid #99ff88 !important;
     /* padding: 10px 0 10px 10px !important; */
     padding: 0 0 0 10px !important;
     margin-right: 0 !important;


### PR DESCRIPTION
In this comment, Eliezer asked for a change to make new comments stand out more: http://lesswrong.com/lw/h8d/ritual_report_schelling_day/8tuu

This is a cheap attempt to do that by using a brighter green.

This is also the first time I've ever tried to change something using Github, so my apologies if it does not work or if I am doing something obvious wrong here!
