### PR TITLE
Prevents blank wiki pages from causing profile pages in user pages.

### DIFF
--- a/r2/r2/lib/wikipagecached.py
+++ b/r2/r2/lib/wikipagecached.py
@@ -98,7 +98,7 @@ class WikiPageCached:
 
     @property
     def success(self):
-        return self.page['success']
+        return self.page['success'] and 'There is currently no text in this page.' not in self.page['content']
 
     def content(self):
         return self.page['content']


### PR DESCRIPTION
http://code.google.com/p/lesswrong/issues/detail?id=401

Checks if the content of the page includes "There is currently no text in this page."  and pretends there isn't a wiki user page if it does.
