### PR TITLE
Fix VM setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,11 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "chef/ubuntu-12.04"
-
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = "https://vagrantcloud.com/chef/boxes/ubuntu-12.04/versions/1.0.0/providers/virtualbox.box"
+  config.vm.box = "bento/ubuntu-12.04"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,

--- a/r2/setup.py
+++ b/r2/setup.py
@@ -96,7 +96,7 @@ setup(
                       "Pylons==0.9.6.2",
                       "pycrypto==2.0.1",
                       "Babel==0.9.6",
-                      "flup<=1.0.3",
+                      "flup==1.0.3.dev-20110405",
                       "simplejson==2.1.1",
                       "SQLAlchemy==0.3.10",
                       "BeautifulSoup==3.0.7a",


### PR DESCRIPTION
This fixes two problems:

  * The `chef/ubuntu-12.04` Vagrant box was renamed to `bento/ubuntu-12.04` and version 1.0 doesn't exist anymore.
  * The latest version of flup doesn't support Python 2, so we need to set it to the last version that does.

See bug #546 