### PR TITLE
Added static content to sidebar - virtual study room

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -153,6 +153,7 @@ class Reddit(Wrapped):
             ps.append(FeedLinkBar(getattr(self, 'canonical_link', request.path)))
 
         ps.append(SideBoxPlaceholder('side-meetups', _('Nearest Meetups'), '/meetups', sr_path=False))
+        ps.append(VirtualStudyRoom())
         ps.append(SideBoxPlaceholder('side-comments', _('Recent Comments'), '/comments'))
         if c.site.name == 'discussion':
             ps.append(SideBoxPlaceholder('side-open', _('Recent Open Threads'), '/tag/open_thread'))
@@ -1597,7 +1598,6 @@ class NumberPollResults(PollResults):
     def __init__(self, poll, *a, **kw):
         PollResults.__init__(self, poll, *a, **kw)
 
-
 class UpcomingMeetups(SpaceCompressedWrapped):
     def __init__(self, location, max_distance, *a, **kw):
         meetups = Meetup.upcoming_meetups_near(location, max_distance, 2)
@@ -1643,6 +1643,7 @@ class MeetupIndex(Wrapped):
 
 class MeetupNotification(Wrapped): pass
 
+class VirtualStudyRoom(Wrapped): pass
 
 class WikiPageInline(Wrapped): pass
 

--- a/r2/r2/templates/virtualstudyroom.html
+++ b/r2/r2/templates/virtualstudyroom.html
@@ -1,0 +1,12 @@
+<div class="sidebox" id="side-studyroom">
+  <h2 class='studyroom-title'>
+    <a href="https://complice.co/room/lesswrong">Virtual Study Room</a>
+  </h2>
+  Co-work with other rationalists online.<br>
+  <ul>
+    <li>
+      <a href="https://complice.co/room/lesswrong"><strong>Less Wrong Study Hall</strong>
+      </a>
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
@wezm I couldn't work out how to use the standard `SideBox` instance. It required that I build an object that responded to `render()` however I couldn't find the methods that generate HTML tags.

Instead, after looking at how the templates are dynamically rendered, this seemed like a simple enough way to do it. Let me know your thoughts and if it's ok to merge.