### PR TITLE
disable user posts to main

### DIFF
--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -196,8 +196,6 @@ class Subreddit(Thing, Printable, ImageHolder):
             return False
         elif self.type == 'public':
             return True
-        elif self == Subreddit._by_name(g.default_sr) and user.safe_karma >= g.karma_to_post:
-            return True
         else:
             return False
 

--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -76,7 +76,7 @@
                       %elif sr._id == thing.sr_id:
                         selected="selected"
                       %endif
-              >${sr.title} ${_('(Your karma must be at least %d to post here)' % g.karma_to_post) if not sr.can_submit(c.user) else ''}
+              >${sr.title} ${'(Posting to main is currently disabled)' if not sr.can_submit(c.user) else ''}
               </option>
             %endfor
           </select>


### PR DESCRIPTION
This is intended to resolve issue #549

can_submit for main now always returns False for non-admins.  Because of this, main is disabled as a submit option in the drop down menu in newlink.html.  I changed the reason to "(Posting to main is currently disabled)" instead of "(Your karma must be at least 40 to post here)."

I tested in the vagrant vm using admin, high karma and low karma users.