### PR TITLE
Disable user posts to main, but permit user edits to existing posts in main

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -301,6 +301,14 @@ class ApiController(RedditController):
               tags = VTags('tags'))
     def POST_submit(self, res, l, new_content, title, save, continue_editing, sr, ip, tags, notify_on_comment, cc_licensed):
         res._update('status', innerHTML = '')
+        
+        if res._chk_error(errors.SUBREDDIT_FORBIDDEN):
+            # although new posts to main are disabled, editing of previous posts is permitted
+            if sr == Subreddit._by_name(g.default_sr) and l.can_submit(c.user):
+                c.errors.remove(errors.SUBREDDIT_FORBIDDEN)
+            else:
+                sr = None
+                
         should_ratelimit = sr.should_ratelimit(c.user, 'link') if sr else True
 
         #remove the ratelimit error if the user's karma is high
@@ -1787,6 +1795,13 @@ class ApiController(RedditController):
             # we're allowing mutliple submissions, so we really just
             # want the URL
             url = url[0].url
+
+        if res._chk_error(errors.SUBREDDIT_FORBIDDEN):
+            # although new posts to main are disabled, editing of previous posts is permitted
+            if sr == Subreddit._by_name(g.default_sr) and l.can_submit(c.user):
+                c.errors.remove(errors.SUBREDDIT_FORBIDDEN)
+            else:
+                sr = None
 
         if res._chk_error(errors.NO_TITLE):
             res._focus('title')

--- a/r2/r2/controllers/validator/validator.py
+++ b/r2/r2/controllers/validator/validator.py
@@ -546,7 +546,6 @@ class VSubmitSR(Validator):
 
         if sr and not (c.user_is_loggedin and sr.can_submit(c.user)):
             c.errors.add(errors.SUBREDDIT_FORBIDDEN)
-            sr = None
 
         return sr
         

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -116,7 +116,7 @@ class Link(Thing, Printable, ImageHolder):
             elif self.author_id == c.user._id:
                 # They can submit if they are the author and still have access
                 # to the subreddit of the article
-                return sr.can_submit(user)
+                return sr.can_submit(user, self)
             else:
                 return False
 

--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -179,7 +179,7 @@ class Subreddit(Thing, Printable, ImageHolder):
         else:
             return False
 
-    def can_submit(self, user):
+    def can_submit(self, user, thing = None):
         if c.user_is_admin:
             return True
         elif self.type == 'private' and self.is_contributor(user):
@@ -195,6 +195,12 @@ class Subreddit(Thing, Printable, ImageHolder):
         elif self == Subreddit._by_name('discussion') and user.safe_karma < g.discussion_karma_to_post:
             return False
         elif self.type == 'public':
+            return True
+        elif (self == Subreddit._by_name(g.default_sr) 
+                and thing 
+                and hasattr(thing, 'sr_id') and Subreddit._byID(thing.sr_id) == Subreddit._by_name(g.default_sr) 
+                and hasattr(thing, 'author_id') and thing.author_id == user._id): 
+            # although new posts to main are disabled, editing of previous posts is permitted
             return True
         else:
             return False

--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -196,8 +196,6 @@ class Subreddit(Thing, Printable, ImageHolder):
             return False
         elif self.type == 'public':
             return True
-        elif self == Subreddit._by_name(g.default_sr) and user.safe_karma >= g.karma_to_post:
-            return True
         else:
             return False
 

--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -76,7 +76,7 @@
                       %elif sr._id == thing.sr_id:
                         selected="selected"
                       %endif
-              >${sr.title} ${_('(Your karma must be at least %d to post here)' % g.karma_to_post) if not sr.can_submit(c.user) else ''}
+              >${sr.title} ${'(Posting to main is currently disabled)' if not sr.can_submit(c.user) else ''}
               </option>
             %endfor
           </select>

--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -71,12 +71,12 @@
           <select id="sr" name="sr">
             %for sr in thing.subreddits:
               <option value="${sr.name}"
-                      %if not sr.can_submit(c.user):
+                      %if not sr.can_submit(c.user, thing):
                         disabled="disabled"
                       %elif sr._id == thing.sr_id:
                         selected="selected"
                       %endif
-              >${sr.title} ${'(Posting to main is currently disabled)' if not sr.can_submit(c.user) else ''}
+              >${sr.title} ${_('(Posting to main is currently disabled)') if not sr.can_submit(c.user, thing) else ''}
               </option>
             %endfor
           </select>


### PR DESCRIPTION
This is intended as an alternate resolution to issue #549.  If this resolution is accepted, PR #556 should be rejected.

Function is identical to #556, except that normal users can now also edit existing posts in main.  This resolution is more complex however, since Subreddit.can_submit() now, at times, depends on the article being edited/submitted.  Subreddit.can_submit (defined in subreddit.py) now takes an additional parameter, a 'thing' which is the target of the submit (by default set to None). If the 'thing' is in the default_sr and the logged in user authored it, then editing is permitted.  Link.can_submit() and newlink.html are updated to use Subreddit.can_submit with the extra parameter.  The submit data validator VSubmitSR also uses Subreddit.can_submit(), but does not have reference to the target 'thing'.  To accommodate this, I made minimal modifications to VSubmitSR and then corrected in POST_submit and POST_edit_promo (the latter is probably not in use in production).  There is precedent for this in the post-validator correction of rate limiting in POST_submit.

I tested in the vagrant vm using admin, high karma and low karma users.  Tested operations included attempting to create a new article, attempting to edit an existing article, using "save and continue" for an article, switching subreddits as an administrator and as an author (and then testing with other users on the 'moved' article), and promoting as an administrator (and then testing with other users on the 'promoted' article).