### PR TITLE
Incorperate upstream fix for captcha module import

### DIFF
--- a/r2/r2/lib/captcha.py
+++ b/r2/r2/lib/captcha.py
@@ -6,19 +6,21 @@
 # software over a computer network and provide for limited attribution for the
 # Original Developer. In addition, Exhibit A has been modified to be consistent
 # with Exhibit B.
-# 
+#
 # Software distributed under the License is distributed on an "AS IS" basis,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 # the specific language governing rights and limitations under the License.
-# 
+#
 # The Original Code is Reddit.
-# 
+#
 # The Original Developer is the Initial Developer.  The Initial Developer of the
 # Original Code is CondeNet, Inc.
-# 
+#
 # All portions of the code written by CondeNet are Copyright (c) 2006-2008
 # CondeNet, Inc. All Rights Reserved.
 ################################################################################
+from __future__ import absolute_import
+
 import random, string
 #TODO find a better way to cache the captchas
 from r2.config import cache
@@ -63,7 +65,7 @@ def valid_solution(iden, solution):
         or not solution
         or len(iden) != IDEN_LENGTH
         or len(solution) != SOL_LENGTH
-        or solution.upper() != cache.get(str(iden))): 
+        or solution.upper() != cache.get(str(iden))):
         solution = make_solution()
         cache.set(str(iden), solution, time = 300)
         return False


### PR DESCRIPTION
On windows and OSX, `vagrant up` fails due to an import error:
```
==> default:   File "/vagrant/r2/r2/lib/Captcha.py", line 25, in <module>
==> default:     from Captcha.Base import randomIdentifier
==> default: ImportError: No module named Base
==> default: ---- End output of "bash"  "/tmp/chef-script20160703-7426-qg0yug" ----
==> default: Ran "bash"  "/tmp/chef-script20160703-7426-qg0yug" returned 1
==> default: [2016-07-03T17:55:30+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

This was fixed by reddit upstream in https://github.com/reddit/reddit/commit/327a5dc301851fd13fe19b8f6b8d0aed608397fd
See also: https://www.reddit.com/r/redditdev/comments/28cf7p/error_with_r2_source_code_no_module_named_base_in/

This change incorporates that fix.