### PR TITLE
Implement per-user vote multiplier. Fixes #568

### DIFF
--- a/r2/r2/config/environment.py
+++ b/r2/r2/config/environment.py
@@ -6,16 +6,16 @@
 # software over a computer network and provide for limited attribution for the
 # Original Developer. In addition, Exhibit A has been modified to be consistent
 # with Exhibit B.
-# 
+#
 # Software distributed under the License is distributed on an "AS IS" basis,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 # the specific language governing rights and limitations under the License.
-# 
+#
 # The Original Code is Reddit.
-# 
+#
 # The Original Developer is the Initial Developer.  The Initial Developer of the
 # Original Code is CondeNet, Inc.
-# 
+#
 # All portions of the code written by CondeNet are Copyright (c) 2006-2008
 # CondeNet, Inc. All Rights Reserved.
 ################################################################################
@@ -61,12 +61,14 @@ def load_environment(global_conf={}, app_conf={}):
     #tmpl_options['myghty.escapes'] = dict(l=webhelpers.auto_link, s=webhelpers.simple_format)
 
     tmpl_options = config['buffet.template_options']
+    tmpl_options['mako.output_encoding'] = 'utf-8'
+    tmpl_options['mako.input_encoding'] = 'utf-8'
     tmpl_options['mako.default_filters'] = ["websafe"]
     tmpl_options['mako.imports'] = \
                                  ["from r2.lib.filters import websafe, unsafe",
                                   "from pylons import c, g, request",
                                   "from pylons.i18n import _, ungettext"]
-    
+
     # Add your own template options config options here,
     # note that all config options will override
     # any Pylons config options

--- a/r2/r2/config/routing.py
+++ b/r2/r2/config/routing.py
@@ -62,7 +62,7 @@ def make_map(global_conf={}, app_conf={}):
        requirements=dict(where='subscriber|contributor|moderator'))
 
     #mc('/stats', controller='front', action='stats')
-
+    mc('/user/:username/multiplier', controller='votemultiplier', action='edit')
     mc('/user/:username/:where', controller='user', action='listing',
        where='profile')
 
@@ -79,11 +79,11 @@ def make_map(global_conf={}, app_conf={}):
     mc('/stylesheet', controller = 'front', action = 'stylesheet')
 
     mc('/', controller='promoted', action='listing')
-    
+
     for name,page in allWikiPagesCached.items():
         if page.has_key('route'):
             mc("/wiki/"+page['route'], controller='wikipage', action='wikipage', name=name)
-        
+
     mc('/invalidate_cache', controller='wikipage', action='invalidate_cache')
 
     listing_controllers = "hot|saved|toplinks|topcomments|new|recommended|randomrising|comments|blessed|recentposts|edits|promoted"
@@ -159,4 +159,3 @@ def make_map(global_conf={}, app_conf={}):
     mc("/*url", controller='front', action='catchall')
 
     return map
-

--- a/r2/r2/controllers/__init__.py
+++ b/r2/r2/controllers/__init__.py
@@ -46,6 +46,8 @@ from listingcontroller import InterestingpostsController
 
 from listingcontroller import MyredditsController
 
+from admincontroller import VotemultiplierController
+
 from feedback import FeedbackController
 from front import FrontController
 from buttons import ButtonsController
@@ -68,4 +70,3 @@ except ImportError:
 
 from admin import AdminController
 from redirect import RedirectController
-

--- a/r2/r2/controllers/admincontroller.py
+++ b/r2/r2/controllers/admincontroller.py
@@ -68,6 +68,5 @@ class VotemultiplierController(RedditController):
             return self.abort404()
 
         self.vuser = vuser
-        captcha = Captcha() if c.user.needs_captcha() else None
-        page = VoteMultiplierEditPage(self.title(), vuser, captcha)
+        page = VoteMultiplierEditPage(self.title(), vuser)
         return page.render()

--- a/r2/r2/controllers/admincontroller.py
+++ b/r2/r2/controllers/admincontroller.py
@@ -1,0 +1,73 @@
+# The contents of this file are subject to the Common Public Attribution
+# License Version 1.0. (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+# http://code.reddit.com/LICENSE. The License is based on the Mozilla Public
+# License Version 1.1, but Sections 14 and 15 have been added to cover use of
+# software over a computer network and provide for limited attribution for the
+# Original Developer. In addition, Exhibit A has been modified to be consistent
+# with Exhibit B.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Original Code is Reddit.
+#
+# The Original Developer is the Initial Developer.  The Initial Developer of the
+# Original Code is CondeNet, Inc.
+#
+# All portions of the code written by CondeNet are Copyright (c) 2006-2008
+# CondeNet, Inc. All Rights Reserved.
+################################################################################
+from reddit_base import RedditController, base_listing
+from validator import *
+
+from r2.models import *
+from r2.lib.pages import *
+from r2.lib.wrapped import Wrapped
+from r2.lib.db.thing import Query, Merge, Relations
+from r2.lib.db import queries
+
+from pylons.i18n import _
+
+
+class VotemultiplierController(RedditController):
+    """Admin page to set a user's vote multiplier.
+
+    Votes by that user are scaled by that multiplier.
+    Vote multiplier of 1 is default.
+    Vote multiplier of 0 means a users votes don't award any karma.
+    Vote multiplier of 2 means a users votes count for twice as much karma.
+    """
+    # page title
+    title_text = ''
+
+    # login box, subreddit box, submit box, etc, visible
+    show_sidebar = True
+
+    # class (probably a subclass of Reddit) to use to render the page.
+    render_cls = Reddit
+
+    #extra parameters to send to the render_cls constructor
+    render_params = {}
+
+    def title(self):
+        return "Edit Vote Multiplier for %s" % (self.vuser.name)
+
+    def rightbox(self):
+        """Contents of the right box when rendering"""
+        pass
+
+    @validate(vuser = VExistingUname('username'),
+              multiplier = nop('multiplier'),
+              success = nop('success'))
+    def GET_edit(self, vuser, multiplier, success):
+        if not c.user_is_admin:
+            return self.abort404()
+        if not vuser or vuser._deleted:
+            return self.abort404()
+
+        self.vuser = vuser
+        captcha = Captcha() if c.user.needs_captcha() else None
+        page = VoteMultiplierEditPage(self.title(), vuser, captcha)
+        return page.render()

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -248,8 +248,7 @@ class ApiController(RedditController):
 
 
     @Json
-    @validate(VCaptcha(),
-              VUser(),
+    @validate(VUser(),
               VAdmin(),
               VModhash(),
               ip = ValidIP(),
@@ -261,8 +260,6 @@ class ApiController(RedditController):
               res._chk_error(errors.AMOUNT_NOT_NUM) or
               res._chk_error(errors.AMOUNT_NEGATIVE)):
             res._focus('amount')
-        elif res._chk_captcha(errors.BAD_CAPTCHA):
-            pass
 
         banned = errors.BANNED_IP in c.errors or errors.BANNED_DOMAIN in c.errors
         if not res.error and not banned:
@@ -330,14 +327,14 @@ class ApiController(RedditController):
               tags = VTags('tags'))
     def POST_submit(self, res, l, new_content, title, save, continue_editing, sr, ip, tags, notify_on_comment, cc_licensed):
         res._update('status', innerHTML = '')
-        
+
         if res._chk_error(errors.SUBREDDIT_FORBIDDEN):
             # although new posts to main are disabled, editing of previous posts is permitted
             if sr == Subreddit._by_name(g.default_sr) and l.can_submit(c.user):
                 c.errors.remove(errors.SUBREDDIT_FORBIDDEN)
             else:
                 sr = None
-                
+
         should_ratelimit = sr.should_ratelimit(c.user, 'link') if sr else True
 
         #remove the ratelimit error if the user's karma is high

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -253,12 +253,12 @@ class ApiController(RedditController):
               VModhash(),
               ip = ValidIP(),
               user = VExistingUname('username'),
-              multiplier = VVoteMultiplierAmount('multiplier', errors.NO_AMOUNT))
+              multiplier = VVoteMultiplierAmount('multiplier', errors.NO_VOTE_MULTIPLIER))
     def POST_votemultiplier(self, res, user, multiplier, ip):
         res._update('status', innerHTML='')
-        if (res._chk_error(errors.NO_AMOUNT) or
-              res._chk_error(errors.AMOUNT_NOT_NUM) or
-              res._chk_error(errors.AMOUNT_NEGATIVE)):
+        if (res._chk_error(errors.NO_VOTE_MULTIPLIER) or
+              res._chk_error(errors.VOTE_MULTIPLIER_NEGETIVE) or
+              res._chk_error(errors.VOTE_MULTIPLIER_NOT_INT)):
             res._focus('amount')
 
         banned = errors.BANNED_IP in c.errors or errors.BANNED_DOMAIN in c.errors

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -247,6 +247,35 @@ class ApiController(RedditController):
             res._update('success', innerHTML='')
 
 
+    @Json
+    @validate(VCaptcha(),
+              VUser(),
+              VAdmin(),
+              VModhash(),
+              ip = ValidIP(),
+              user = VExistingUname('username'),
+              multiplier = VVoteMultiplierAmount('multiplier', errors.NO_AMOUNT))
+    def POST_votemultiplier(self, res, user, multiplier, ip):
+        res._update('status', innerHTML='')
+        if (res._chk_error(errors.NO_AMOUNT) or
+              res._chk_error(errors.AMOUNT_NOT_NUM) or
+              res._chk_error(errors.AMOUNT_NEGATIVE)):
+            res._focus('amount')
+        elif res._chk_captcha(errors.BAD_CAPTCHA):
+            pass
+
+        banned = errors.BANNED_IP in c.errors or errors.BANNED_DOMAIN in c.errors
+        if not res.error and not banned:
+            user.vote_multiplier = multiplier
+            user._commit()
+
+            res._update('success',
+                        innerHTML=_("Vote multiplier updated"))
+            res._update('multiplier', value=str(multiplier))
+            res._redirect('/user/{0}'.format(user.name))
+        else:
+            res._update('success', innerHTML='')
+
 
     @Json
     @validate(VAdmin(),

--- a/r2/r2/controllers/listingcontroller.py
+++ b/r2/r2/controllers/listingcontroller.py
@@ -691,6 +691,7 @@ class MessageController(ListingController):
                                  success = success)
         return MessagePage(content = content, title = self.title('compose')).render()
 
+
 class KarmaawardController(ListingController):
     show_sidebar = True
 
@@ -914,7 +915,7 @@ def last_dashboard_visit():
         return cache_visit
     else:
         last_visit = c.user.dashboard_visit
-        g.permacache.set(hc_key, last_visit, time = int(g.dashboard_visits_period)) 
+        g.permacache.set(hc_key, last_visit, time = int(g.dashboard_visits_period))
         c.user.dashboard_visit = datetime.now(g.tz)
         c.user._commit()
         return last_visit

--- a/r2/r2/controllers/validator/validator.py
+++ b/r2/r2/controllers/validator/validator.py
@@ -158,17 +158,17 @@ class VVoteMultiplierAmount(Validator):
             c.errors.add(e)
 
     def run(self, item):
-        if not item:
+        if not item or len(item) == 0:
             self.error()
         else:
             try:
                 item = int(item)
                 if item < 0:
-                    c.errors.add(errors.AMOUNT_NEGATIVE)
+                    c.errors.add(errors.VOTE_MULTIPLIER_NEGETIVE)
                 else:
                     return item
             except ValueError:
-                c.errors.add(errors.AMOUNT_NOT_NUM)
+                c.errors.add(errors.VOTE_MULTIPLIER_NOT_INT)
 
 class ValueOrBlank(Validator):
     def run(self, value):

--- a/r2/r2/controllers/validator/validator.py
+++ b/r2/r2/controllers/validator/validator.py
@@ -6,16 +6,16 @@
 # software over a computer network and provide for limited attribution for the
 # Original Developer. In addition, Exhibit A has been modified to be consistent
 # with Exhibit B.
-# 
+#
 # Software distributed under the License is distributed on an "AS IS" basis,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 # the specific language governing rights and limitations under the License.
-# 
+#
 # The Original Code is Reddit.
-# 
+#
 # The Original Developer is the Initial Developer.  The Initial Developer of the
 # Original Code is CondeNet, Inc.
-# 
+#
 # All portions of the code written by CondeNet are Copyright (c) 2006-2008
 # CondeNet, Inc. All Rights Reserved.
 ################################################################################
@@ -70,11 +70,11 @@ def validate(*simple_vals, **param_vals):
             try:
                 for validator in simple_vals:
                     validator(env)
-                
+
                 kw = self.build_arg_list(fn, env)
                 for var, validator in param_vals.iteritems():
                     kw[var] = validator(env)
-                
+
                 return fn(self, *a, **kw)
 
             except UserRequiredException:
@@ -109,7 +109,7 @@ class VRequired(Validator):
         if not e: e = self._error
         if e:
             c.errors.add(e)
-        
+
     def run(self, item):
         if not item:
             self.error()
@@ -134,13 +134,36 @@ class VAwardAmount(Validator):
         if not e: e = self._error
         if e:
             c.errors.add(e)
-        
+
     def run(self, item):
         if not item:
             self.error()
         else:
             try:
                 if int(item) <= 0:
+                    c.errors.add(errors.AMOUNT_NEGATIVE)
+                else:
+                    return item
+            except ValueError:
+                c.errors.add(errors.AMOUNT_NOT_NUM)
+
+class VVoteMultiplierAmount(Validator):
+    def __init__(self, param, error, *a, **kw):
+        Validator.__init__(self, param, *a, **kw)
+        self._error = error
+
+    def error(self, e = None):
+        if not e: e = self._error
+        if e:
+            c.errors.add(e)
+
+    def run(self, item):
+        if not item:
+            self.error()
+        else:
+            try:
+                item = int(item)
+                if item < 0:
                     c.errors.add(errors.AMOUNT_NEGATIVE)
                 else:
                     return item
@@ -156,7 +179,7 @@ class VLink(Validator):
     def __init__(self, param, redirect = True, *a, **kw):
         Validator.__init__(self, param, *a, **kw)
         self.redirect = redirect
-    
+
     def run(self, link_id):
         if link_id:
             try:
@@ -170,7 +193,7 @@ class VLink(Validator):
 
 class VCommentFullName(Validator):
     valid_re = re.compile(Comment._type_prefix + str(Comment._type_id) + r'_([0-9a-z]+)$')
-    
+
     def run(self, thing_fullname):
         if thing_fullname:
             match = self.valid_re.match(thing_fullname)
@@ -203,7 +226,7 @@ class VEditMeetup(VMeetup):
 
     def run(self, param):
         meetup = VMeetup.run(self, param)
-        if meetup and not (c.user_is_loggedin and 
+        if meetup and not (c.user_is_loggedin and
                            meetup.can_edit(c.user, c.user_is_admin)):
             abort(403, "forbidden")
         return meetup
@@ -211,7 +234,7 @@ class VEditMeetup(VMeetup):
 class VTagByName(Validator):
     def __init__(self, param, *a, **kw):
         Validator.__init__(self, param, *a, **kw)
-        
+
     def run(self, name):
         if name:
             cleaned = _force_ascii(name)
@@ -224,10 +247,10 @@ class VTagByName(Validator):
 
 class VTags(Validator):
     comma_sep = re.compile('[,\s]+', re.UNICODE)
-    
+
     def __init__(self, param, *a, **kw):
         Validator.__init__(self, param, *a, **kw)
-        
+
     def run(self, tag_field):
         tags = []
         if tag_field:
@@ -266,7 +289,7 @@ class VCount(Validator):
 class VLimit(Validator):
     def run(self, limit):
         if limit is None:
-            return c.user.pref_numsites 
+            return c.user.pref_numsites
         return min(max(int(limit), 1), 250)
 
 class VCssMeasure(Validator):
@@ -293,7 +316,7 @@ class VLinkUrls(Validator):
     def __init__(self, item, *a, **kw):
         self.item = item
         Validator.__init__(self, item, *a, **kw)
-    
+
     def run(self, val):
         res=[]
         for v in self.splitter.split(val):
@@ -313,11 +336,11 @@ class VLinkFullnames(Validator):
     def __init__(self, item, *a, **kw):
         self.item = item
         Validator.__init__(self, item, *a, **kw)
-    
+
     def run(self, val):
         if val and self.valid_re.match(val):
             return self.splitter.split(val)
-    
+
 class VLength(Validator):
     def __init__(self, item, length = 10000,
                  empty_error = errors.BAD_COMMENT,
@@ -335,10 +358,10 @@ class VLength(Validator):
             c.errors.add(self.len_error)
         else:
             return title
-        
+
 class VTitle(VLength):
     only_whitespace = re.compile(r"^\s*$", re.UNICODE)
-    
+
     def __init__(self, item, length = 200, **kw):
         VLength.__init__(self, item, length = length,
                          empty_error = errors.NO_TITLE,
@@ -350,15 +373,15 @@ class VTitle(VLength):
             c.errors.add(errors.NO_TITLE)
         else:
             return title
-    
+
 class VComment(VLength):
     def __init__(self, item, length = 10000, **kw):
         VLength.__init__(self, item, length = length, **kw)
 
-        
+
 class VMessage(VLength):
     def __init__(self, item, length = 10000, **kw):
-        VLength.__init__(self, item, length = length, 
+        VLength.__init__(self, item, length = length,
                          empty_error = errors.NO_MSG_BODY, **kw)
 
 
@@ -395,7 +418,7 @@ class VSubredditDesc(Validator):
 class VAccountByName(VRequired):
     def __init__(self, param, error = errors.USER_DOESNT_EXIST, *a, **kw):
         VRequired.__init__(self, param, error, *a, **kw)
-        
+
     def run(self, name):
         if name:
             try:
@@ -404,7 +427,7 @@ class VAccountByName(VRequired):
         return self.error()
 
 class VByName(VRequired):
-    def __init__(self, param, 
+    def __init__(self, param,
                  error = errors.NO_THING_ID, *a, **kw):
         VRequired.__init__(self, param, error, *a, **kw)
 
@@ -427,7 +450,7 @@ class VByNameIfAuthor(VByName):
 
 class VCaptcha(Validator):
     default_param = ('iden', 'captcha')
-    
+
     def run(self, iden, solution):
         if (not c.user_is_loggedin or c.user.needs_captcha()):
             if not captcha.valid_solution(iden, solution):
@@ -440,7 +463,7 @@ class VUser(Validator):
 
         if (password is not None) and not valid_password(c.user, password):
             c.errors.add(errors.WRONG_PASSWORD)
-            
+
 class VModhash(Validator):
     default_param = 'uh'
     def run(self, uh):
@@ -468,7 +491,7 @@ class VSponsor(Validator):
 
 class VSrModerator(Validator):
     def run(self):
-        if not (c.user_is_loggedin and c.site.is_moderator(c.user) 
+        if not (c.user_is_loggedin and c.site.is_moderator(c.user)
                 or c.user_is_admin):
             abort(403, "forbidden")
 
@@ -525,11 +548,11 @@ class VSubmitParent(Validator):
                     return parent
         #else
         abort(403, "forbidden")
-        
+
 class VSubmitLink(VLink):
     def __init__(self, param, redirect = True, *a, **kw):
         VLink.__init__(self, param, redirect = redirect, *a, **kw)
-        
+
     def run(self, link_name):
         link = VLink.run(self, link_name)
         if link and not (c.user_is_loggedin and link.can_submit(c.user)):
@@ -548,7 +571,7 @@ class VSubmitSR(Validator):
             c.errors.add(errors.SUBREDDIT_FORBIDDEN)
 
         return sr
-        
+
 pass_rx = re.compile(r".{3,20}")
 
 def chkpass(x):
@@ -602,7 +625,7 @@ class VUname(VRequired):
 class VLogin(VRequired):
     def __init__(self, item, *a, **kw):
         VRequired.__init__(self, item, errors.WRONG_PASSWORD, *a, **kw)
-        
+
     def run(self, user_name, password):
         user_name = chkuser(user_name)
         user = None
@@ -640,7 +663,7 @@ class VUrl(VRequired):
                 sr = None
         else:
             sr = None
-        
+
         if not url:
             return self.error(errors.NO_URL)
         url = utils.sanitize_url(url)
@@ -694,7 +717,7 @@ class VBoolean(Validator):
 
 class VLocation(VLength):
     def __init__(self, item, length = 100, **kw):
-        VLength.__init__(self, item, length = length, 
+        VLength.__init__(self, item, length = length,
                          length_error = errors.LOCATION_TOO_LONG,
                          empty_error = None, **kw)
 
@@ -759,7 +782,7 @@ class VCssName(Validator):
     def run(self, name):
         if name and self.r_css_name.match(name):
             return name
-    
+
 class VMenu(Validator):
 
     def __init__(self, param, menu_cls, remember = True, default_item = None, **kw):
@@ -774,14 +797,14 @@ class VMenu(Validator):
             pref = "%s_%s" % (where, self.nav.get_param)
             user_prefs = copy(c.user.sort_options) if c.user else {}
             user_pref = user_prefs.get(pref)
-    
+
             # check to see if a default param has been set
             if not sort:
                 sort = user_pref
 
         if not sort:
             sort = self.default_item
-            
+
         # validate the sort
         if sort not in self.nav.options:
             sort = self.nav.default
@@ -794,7 +817,7 @@ class VMenu(Validator):
             utils.worker.do(lambda: user._commit())
 
         return sort
-            
+
 
 class VRatelimit(Validator):
     def __init__(self, rate_user = False, rate_ip = False,
@@ -891,7 +914,7 @@ class VReason(Validator):
 
         if reason.startswith('redirect_'):
             dest = reason[9:]
-            if (not dest.startswith(c.site.path) and 
+            if (not dest.startswith(c.site.path) and
                 not dest.startswith("http:")):
                 dest = (c.site.path + dest).replace('//', '/')
             return ('redirect', dest)
@@ -917,12 +940,12 @@ class VReason(Validator):
 
 class ValidEmail(Validator):
     """Validates an email address"""
-    
+
     email_re  = re.compile(r'.+@.+\..+')
 
     def __init__(self, param, **kw):
         Validator.__init__(self, param = param, **kw)
-        
+
     def run(self, email):
         if not email:
             c.errors.add(errors.NO_EMAIL)
@@ -936,14 +959,14 @@ class ValidEmails(Validator):
     delineated by whitespace, ',' or ';'.  Also validates quantity of
     provided emails.  Returns a list of valid email addresses on
     success"""
-    
+
     separator = re.compile(r'[^\s,;]+')
     email_re  = re.compile(r'.+@.+\..+')
 
     def __init__(self, param, num = 20, **kw):
         self.num = num
         Validator.__init__(self, param = param, **kw)
-        
+
     def run(self, emails0):
         emails = set(self.separator.findall(emails0) if emails0 else [])
         failures = set(e for e in emails if not self.email_re.match(e))

--- a/r2/r2/lib/errors.py
+++ b/r2/r2/lib/errors.py
@@ -6,16 +6,16 @@
 # software over a computer network and provide for limited attribution for the
 # Original Developer. In addition, Exhibit A has been modified to be consistent
 # with Exhibit B.
-# 
+#
 # Software distributed under the License is distributed on an "AS IS" basis,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 # the specific language governing rights and limitations under the License.
-# 
+#
 # The Original Code is Reddit.
-# 
+#
 # The Original Developer is the Initial Developer.  The Initial Developer of the
 # Original Code is CondeNet, Inc.
-# 
+#
 # All portions of the code written by CondeNet are Copyright (c) 2006-2008
 # CondeNet, Inc. All Rights Reserved.
 ################################################################################
@@ -84,7 +84,10 @@ error_list = dict((
         ('BAD_POLL_SYNTAX', _('Error in poll syntax')),
         ('BAD_POLL_BALLOT', _('Error in poll ballot')),
         ('WIKI_DOWN', _('Connection with wiki failed, try again later')),
-        ('WIKI_ACCOUNT_CREATION_FAILED', _('Wiki account creation failed. Check your email for further instructions.'))
+        ('WIKI_ACCOUNT_CREATION_FAILED', _('Wiki account creation failed. Check your email for further instructions.')),
+        ('NO_VOTE_MULTIPLIER', _("Vote multiplier is required")),
+        ('VOTE_MULTIPLIER_NEGETIVE', _("Must not be negative")),
+        ('VOTE_MULTIPLIER_NOT_INT', _("Must be an integer"))
     ))
 errors = Storage([(e, e) for e in error_list.keys()])
 
@@ -94,7 +97,7 @@ class Error(object):
         self.name = name
         self.i18n_message = i18n_message
         self.msg_params = msg_params or {}
-        
+
     @property
     def message(self):
         return _(self.i18n_message) % self.msg_params
@@ -123,10 +126,10 @@ class ErrorSet(object):
     def __iter__(self):
         for x in self.errors:
             yield x
-        
+
     def _add(self, error_name, msg, msg_params = None):
         self.errors[error_name] = Error(error_name, msg, msg_params)
-        
+
     def add(self, error_name, msg_params = None):
         msg = error_list[error_name]
         self._add(error_name,  msg, msg_params = msg_params)

--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -6,16 +6,16 @@
 # software over a computer network and provide for limited attribution for the
 # Original Developer. In addition, Exhibit A has been modified to be consistent
 # with Exhibit B.
-# 
+#
 # Software distributed under the License is distributed on an "AS IS" basis,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 # the specific language governing rights and limitations under the License.
-# 
+#
 # The Original Code is Reddit.
-# 
+#
 # The Original Developer is the Initial Developer.  The Initial Developer of the
 # Original Code is CondeNet, Inc.
-# 
+#
 # All portions of the code written by CondeNet are Copyright (c) 2006-2008
 # CondeNet, Inc. All Rights Reserved.
 ################################################################################
@@ -29,7 +29,7 @@ def api_type(subtype = ''):
 def is_api(subtype = ''):
     from pylons import c
     return c.render_style and c.render_style.startswith(api_type(subtype))
-    
+
 def get_api_subtype():
     from pylons import c
     if is_api() and c.render_style.startswith('api-'):
@@ -54,12 +54,12 @@ class JsonTemplate(Template):
 
 class ThingJsonTemplate(JsonTemplate):
     __data_attrs__ = dict()
-    
+
     def points(self, wrapped):
         scores = wrapped.score_triplet(wrapped.likes)
         return map(wrapped.score_fmt, scores)
-        
-    
+
+
     def kind(self, wrapped):
         _thing = wrapped.lookups[0] if isinstance(wrapped, Wrapped) else wrapped
         return make_typename(_thing.__class__)
@@ -84,10 +84,10 @@ class ThingJsonTemplate(JsonTemplate):
                 return x.render()
             else:
                 return x
-        
+
         return dict((k, strip_data(self.thing_attr(thing, v)))
                     for k, v in self.__data_attrs__.iteritems())
-            
+
     def thing_attr(self, thing, attr):
         import time
         if attr == "author":
@@ -105,10 +105,10 @@ class ThingJsonTemplate(JsonTemplate):
             return self.rendered_data(thing)
         else:
             return self.raw_data(thing)
-        
+
     def render(self, thing = None, action = None, *a, **kw):
         return dict(kind = self.kind(thing), data = self.data(thing))
-        
+
 class SubredditJsonTemplate(ThingJsonTemplate):
     __data_attrs__ = dict(id           = "_id36",
                           name         = "_fullname",
@@ -131,7 +131,7 @@ class LinkJsonTemplate(ThingJsonTemplate):
                           domain       = "domain",
                           title        = "title",
                           url          = "url",
-                          author       = "author", 
+                          author       = "author",
                           num_comments = "num_comments",
                           created      = "created",
                           subreddit    = "subreddit",
@@ -143,7 +143,7 @@ class LinkJsonTemplate(ThingJsonTemplate):
         elif attr == 'subreddit_id':
             return thing.subreddit._fullname
         return ThingJsonTemplate.thing_attr(self, thing, attr)
-                          
+
     def rendered_data(self, thing):
         d = ThingJsonTemplate.rendered_data(self, thing)
         d['sr'] = thing.subreddit._fullname
@@ -159,7 +159,7 @@ class CommentJsonTemplate(ThingJsonTemplate):
                           replies      = "child",
                           body         = "body",
                           likes        = "likes",
-                          author       = "author", 
+                          author       = "author",
                           created      = "created",
                           link_id      = "link_id",
                           parent_id    = "parent_id",
@@ -242,7 +242,7 @@ class PanestackJsonTemplate(JsonTemplate):
         res = [x for x in res if x]
         if not res:
             return {}
-        return res if len(res) > 1 else res[0] 
+        return res if len(res) > 1 else res[0]
 
 class NullJsonTemplate(JsonTemplate):
     def render(self, thing = None, *a, **kw):
@@ -250,7 +250,7 @@ class NullJsonTemplate(JsonTemplate):
 
 class ListingJsonTemplate(ThingJsonTemplate):
     __data_attrs__ = dict(children = "things")
-    
+
     def points(self, w):
         return []
 
@@ -266,7 +266,7 @@ class ListingJsonTemplate(ThingJsonTemplate):
                 r = spaceCompress(r)
             res.append(r)
         return res
-    
+
     def kind(self, wrapped):
         return "Listing"
 

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -573,6 +573,7 @@ class KarmaAward(Wrapped):
                          reason = reason, success = success,
                          captcha = captcha)
 
+
 class BoringPage(Reddit):
     """parent class For rendering all sorts of uninteresting,
     sortless, navless form-centric pages.  The top navmenu is
@@ -612,6 +613,25 @@ class Login(Wrapped):
     def __init__(self, user_reg = '', user_login = '', dest=''):
         Wrapped.__init__(self, user_reg = user_reg, user_login = user_login,
                          dest = dest)
+
+class VoteMultiplierEditPage(BoringPage):
+    searchbox = False
+    navlist = False
+
+    def __init__(self, title, user, captcha, *a, **kw):
+        self.captcha = captcha
+        self.user = user
+        BoringPage.__init__(self, title)
+
+    def content(self):
+        return VoteMultiplierEdit(self.user, self.captcha)
+
+class VoteMultiplierEdit(Wrapped):
+    def __init__(self, user, captcha, success = False):
+        Wrapped.__init__(self, success = success,
+                               username = user.name,
+                               vote_multiplier = user.vote_multiplier,
+                               captcha = captcha)
 
 class VerifyEmail(Wrapped):
     def __init__(self, success=False):

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -618,20 +618,18 @@ class VoteMultiplierEditPage(BoringPage):
     searchbox = False
     navlist = False
 
-    def __init__(self, title, user, captcha, *a, **kw):
-        self.captcha = captcha
+    def __init__(self, title, user, *a, **kw):
         self.user = user
         BoringPage.__init__(self, title)
 
     def content(self):
-        return VoteMultiplierEdit(self.user, self.captcha)
+        return VoteMultiplierEdit(self.user)
 
 class VoteMultiplierEdit(Wrapped):
-    def __init__(self, user, captcha, success = False):
+    def __init__(self, user, success = False):
         Wrapped.__init__(self, success = success,
                                username = user.name,
-                               vote_multiplier = user.vote_multiplier,
-                               captcha = captcha)
+                               vote_multiplier = user.vote_multiplier)
 
 class VerifyEmail(Wrapped):
     def __init__(self, success=False):

--- a/r2/r2/models/account.py
+++ b/r2/r2/models/account.py
@@ -80,6 +80,7 @@ class Account(Thing):
                      report_correct = 0,
                      report_ignored = 0,
                      spammer = 0,
+                     vote_multiplier = 1,
                      sort_options = {},
                      has_subscribed = False,
                      pref_media = 'subreddit',
@@ -284,6 +285,7 @@ class Account(Thing):
 
         karma_balance = self.safe_karma * 4
         vote_cost = c.current_or_default_sr.post_karma_multiplier if vote_kind == 'link' else 1
+        vote_cost *= self.vote_multiplier
         if karma_spent + vote_cost > karma_balance:
             points_needed = abs(karma_balance - karma_spent - vote_cost)
             msg = strings.not_enough_downvote_karma % (points_needed, plurals.N_points(points_needed))

--- a/r2/r2/models/builder.py
+++ b/r2/r2/models/builder.py
@@ -6,16 +6,16 @@
 # software over a computer network and provide for limited attribution for the
 # Original Developer. In addition, Exhibit A has been modified to be consistent
 # with Exhibit B.
-# 
+#
 # Software distributed under the License is distributed on an "AS IS" basis,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 # the specific language governing rights and limitations under the License.
-# 
+#
 # The Original Code is Reddit.
-# 
+#
 # The Original Developer is the Initial Developer.  The Initial Developer of the
 # Original Code is CondeNet, Inc.
-# 
+#
 # All portions of the code written by CondeNet are Copyright (c) 2006-2008
 # CondeNet, Inc. All Rights Reserved.
 ################################################################################
@@ -119,10 +119,14 @@ class Builder(object):
                 w.subreddit = subreddits[item.sr_id]
 
             vote = likes.get((user, item))
-            if vote:
-                w.likes = (True if vote._name == '1'
-                             else False if vote._name == '-1'
-                             else None)
+            if vote is not None:
+                amount = int(vote._name)
+                if amount > 0:
+                    w.likes = True
+                elif amount < 0:
+                    w.likes = False
+                else:
+                    w.likes = None
             else:
                 w.likes = None
 
@@ -131,7 +135,7 @@ class Builder(object):
 
             # update vote tallies
             compute_votes(w, item)
-            
+
             w.score = [w.upvotes, w.downvotes]
             w.deleted = item._deleted
 
@@ -210,7 +214,7 @@ class QueryBuilder(Builder):
         self.start_count = kw.get('count', 0) or 0
         self.after = kw.get('after')
         self.reverse = kw.get('reverse')
-        
+
         self.prewrap_fn = None
         if hasattr(query, 'prewrap_fn'):
             self.prewrap_fn = query.prewrap_fn
@@ -270,7 +274,7 @@ class QueryBuilder(Builder):
 
         #logloop
         self.loopcount = 0
-        
+
         while not done:
             done, new_items = self.fetch_more(last_item, num_have)
 
@@ -315,7 +319,7 @@ class QueryBuilder(Builder):
                 if self.wrap:
                     i.num = count
                 last_item = i
-        
+
         #unprewrap the last item
         if self.prewrap_fn and last_item:
             last_item = orig_items[last_item._id]
@@ -566,7 +570,7 @@ class CommentBuilder(CommentBuilderMixin, Builder):
             top = self.comment[0]
             #assume the comments all have the same parent
             # TODO: removed by Chris to get rid of parent being sent
-            # when morecomments is used.  
+            # when morecomments is used.
             #if hasattr(candidates[0], "parent_id"):
             #    parent = comment_dict[candidates[0].parent_id]
             #    items.append(parent)
@@ -596,7 +600,7 @@ class CommentBuilder(CommentBuilderMixin, Builder):
 
         def sort_candidates():
             candidates.sort(key = self.sort_key, reverse = self.rev_sort)
-        
+
         #find the comments
         num_have = 0
         sort_candidates()
@@ -622,7 +626,7 @@ class CommentBuilder(CommentBuilderMixin, Builder):
         wrapped = self.wrap_items(items)
 
         cids = dict((cm._id, cm) for cm in wrapped)
-        
+
         final = []
         #make tree
 
@@ -691,7 +695,7 @@ class CommentBuilder(CommentBuilderMixin, Builder):
             #add more children
             if comment_tree.has_key(to_add._id):
                 candidates.extend(comment_tree[to_add._id])
-                
+
             if direct_child:
                 mc2.children.append(to_add)
 

--- a/r2/r2/models/vote.py
+++ b/r2/r2/models/vote.py
@@ -6,16 +6,16 @@
 # software over a computer network and provide for limited attribution for the
 # Original Developer. In addition, Exhibit A has been modified to be consistent
 # with Exhibit B.
-# 
+#
 # Software distributed under the License is distributed on an "AS IS" basis,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 # the specific language governing rights and limitations under the License.
-# 
+#
 # The Original Code is Reddit.
-# 
+#
 # The Original Developer is the Initial Developer.  The Initial Developer of the
 # Original Code is CondeNet, Inc.
-# 
+#
 # All portions of the code written by CondeNet are Copyright (c) 2006-2008
 # CondeNet, Inc. All Rights Reserved.
 ################################################################################
@@ -83,6 +83,9 @@ class Vote(MultiRelation('vote',
                                       data = True))
 
             amount = 1 if dir is True else 0 if dir is None else -1
+            # Users have a vote_multiplier which effects how much their votes are worth
+            if isinstance(sub, Account):
+                amount *= sub.vote_multiplier
 
             lock.log('voting checkpoint D')
 
@@ -144,8 +147,6 @@ class Vote(MultiRelation('vote',
     #TODO make this generic and put on multirelation?
     @classmethod
     def likes(cls, sub, obj):
-        votes = cls._fast_query(sub, obj, ('1', '-1'), data=False)
+        votes = cls._fast_query(sub, obj, None, data=False)
         votes = dict((tuple(k[:2]), v) for k, v in votes.iteritems() if v)
         return votes
-
-

--- a/r2/r2/public/static/lesswrong.css
+++ b/r2/r2/public/static/lesswrong.css
@@ -253,6 +253,7 @@ h1 a, h2 a {
 .pretty-form input[type=text],
 .pretty-form input[type=file],
 .pretty-form input[type=password],
+.pretty-form input[type=number],
 .pretty-form select,
 .pretty-form b,
 .pretty-form textarea,

--- a/r2/r2/public/static/main.css
+++ b/r2/r2/public/static/main.css
@@ -996,6 +996,7 @@ div.sidebox select {
 	font-weight: bold;
 	line-height: 22px;
 }
+
 #side-status div.userinfo span.mail {
     margin-top: 8px;
     clear: both;

--- a/r2/r2/public/static/vote_piece.js
+++ b/r2/r2/public/static/vote_piece.js
@@ -13,16 +13,16 @@ function cookieName(name) {
     return (logged || '') + "_" + name;
 }
 
-function createLCookie(name,value,days) { 
+function createLCookie(name,value,days) {
     var domain = "; domain=" + cur_domain;
-    if (days) { 
+    if (days) {
         var date = new Date();
         date.setTime(date.getTime()+(days*24*60*60*1000));
         var expires="; expires="+date.toGMTString();
     }
     else expires="";
     document.cookie=name+"="+ escape(value) +expires+domain+"; path=/";
-} 
+}
 
 function createCookie(name, value, days) {
   return createLCookie(cookieName(name), value, days);
@@ -32,15 +32,15 @@ function readLCookie(nameEQ) {
     nameEQ=nameEQ+'=';
     var ca=document.cookie.split(';');
     /* walk the list backwards so we always get the last cookie in the list */
-    for(var i = ca.length-1; i >= 0; i--) { 
-        var c = ca[i]; 
+    for(var i = ca.length-1; i >= 0; i--) {
+        var c = ca[i];
         while(c.charAt(0)==' ') c=c.substring(1,c.length);
         if(c.indexOf(nameEQ)==0) {
           /* we can unescape even if it's not escaped */
           return unescape(c.substring(nameEQ.length,c.length));
         }
     }
-    return '';  
+    return '';
 }
 
 function readCookie(name) {

--- a/r2/r2/templates/printable.html
+++ b/r2/r2/templates/printable.html
@@ -195,12 +195,12 @@ ${self.RenderPrintable()}
 <%def name="score(this, likes=None, inline=True, label = True, _id = True)">
 <%
    tag = "span" if inline else "div"
-   _class = "" if likes is None else "likes" if likes else "dislikes"
+   _class = "" if likes == None else "likes" if likes else "dislikes"
    _id = ("id='score_%s'" % this._fullname) if _id else ""
 
    # figure out alterna-points
    score = thing.score_fmt((this._ups, this._downs))
-   base_scores = map(thing.score_fmt, this.score_triplet(likes))
+   base_scores = map(thing.score_fmt, this.score_triplet(likes=likes, multiplier=c.user.vote_multiplier))
  %>
   <${tag} class="votes ${_class}" ${_id}
       %if score['hover']:
@@ -304,4 +304,3 @@ ${k.strip('_')}="${v}" \
   ${plain_link(link_text, link, id="%s_%s" % (name, fullname), _class="%s %s" % (a_class, cls), title=title, target=target)}
 
 </%def>
-

--- a/r2/r2/templates/profilebar.html
+++ b/r2/r2/templates/profilebar.html
@@ -6,16 +6,16 @@
 ## software over a computer network and provide for limited attribution for the
 ## Original Developer. In addition, Exhibit A has been modified to be consistent
 ## with Exhibit B.
-## 
+##
 ## Software distributed under the License is distributed on an "AS IS" basis,
 ## WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 ## the specific language governing rights and limitations under the License.
-## 
+##
 ## The Original Code is Reddit.
-## 
+##
 ## The Original Developer is the Initial Developer.  The Initial Developer of
 ## the Original Code is CondeNet, Inc.
-## 
+##
 ## All portions of the code written by CondeNet are Copyright (c) 2006-2008
 ## CondeNet, Inc. All Rights Reserved.
 ################################################################################
@@ -39,6 +39,9 @@
         %if c.user_is_admin:
           <li>
             ${plain_link(_("Award karma"), "/karma/award/?to=%s" % thing.user.name)}
+          </li>
+          <li>
+            ${plain_link(_("Vote multiplier"), "user/%s/multiplier" % thing.user.name)}
           </li>
         %endif
         <li>
@@ -81,6 +84,9 @@
       </span>
       %if thing.user.name in g.admins:
         <span class="role">Editor</span>
+      %endif
+      %if thing.user.vote_multiplier != 1:
+        <span class="role">${thing.user.vote_multiplier}x vote multiplier</span>
       %endif
 
       %if thing.isMe:

--- a/r2/r2/templates/profilebar.html
+++ b/r2/r2/templates/profilebar.html
@@ -85,9 +85,6 @@
       %if thing.user.name in g.admins:
         <span class="role">Editor</span>
       %endif
-      %if thing.user.vote_multiplier != 1:
-        <span class="role">${thing.user.vote_multiplier}x vote multiplier</span>
-      %endif
 
       %if thing.isMe:
         <%
@@ -113,6 +110,10 @@
       %if thing.user.pref_url:
         <dt>Website</dt>
         <dd><a href="${thing.user.pref_url}" rel="nofollow">${thing.user.pref_url}</a></dd>
+      %endif
+      %if thing.user.vote_multiplier != 1:
+        <dt></dt>
+        <dd>${thing.user.vote_multiplier}⨉ vote multiplier</dd>
       %endif
     </dl>
 

--- a/r2/r2/templates/votemultiplieredit.html
+++ b/r2/r2/templates/votemultiplieredit.html
@@ -31,9 +31,6 @@ ${success_field(_("Vote multiplier set"),
         ${error_field("AMOUNT_NOT_NUM", "span")}
         ${error_field("AMOUNT_NEGATIVE", "span")}</td>
     </tr>
-    %if thing.captcha:
-      ${thing.captcha.render()}
-    %endif
     <tr>
       <th>
         <label for="submit"></label>

--- a/r2/r2/templates/votemultiplieredit.html
+++ b/r2/r2/templates/votemultiplieredit.html
@@ -26,9 +26,9 @@ ${success_field(_("Vote multiplier set"),
                size="40"
                id="multiplier"
                value="${thing.vote_multiplier}"/>
-        ${error_field("NO_AMOUNT", "span")}
-        ${error_field("AMOUNT_NOT_NUM", "span")}
-        ${error_field("AMOUNT_NEGATIVE", "span")}
+        ${error_field("NO_VOTE_MULTIPLIER", "span")}
+        ${error_field("VOTE_MULTIPLIER_NOT_INT", "span")}
+        ${error_field("VOTE_MULTIPLIER_NEGETIVE", "span")}
       </td>
     </tr>
     <tr>

--- a/r2/r2/templates/votemultiplieredit.html
+++ b/r2/r2/templates/votemultiplieredit.html
@@ -26,10 +26,10 @@ ${success_field(_("Vote multiplier set"),
                size="40"
                id="multiplier"
                value="${thing.vote_multiplier}"/>
-      </td>
-      <td>${error_field("NO_AMOUNT", "span")}
+        ${error_field("NO_AMOUNT", "span")}
         ${error_field("AMOUNT_NOT_NUM", "span")}
-        ${error_field("AMOUNT_NEGATIVE", "span")}</td>
+        ${error_field("AMOUNT_NEGATIVE", "span")}
+      </td>
     </tr>
     <tr>
       <th>

--- a/r2/r2/templates/votemultiplieredit.html
+++ b/r2/r2/templates/votemultiplieredit.html
@@ -1,0 +1,47 @@
+<%namespace file="utils.html" import="error_field, submit_form, success_field"/>
+
+<h1>${_("Edit Vote Multiplier for")} ${thing.username}</h1>
+
+<p>
+  By setting a user's vote multipler, admins can control how much karma a user's votes count for.
+  Vote multiplier must be a non-negetive integer, and only effects new votes.
+</p>
+
+${success_field(_("Vote multiplier set"),
+                successful=thing.success)}
+
+<%call expr="submit_form(onsubmit='return post_form(this, \'votemultiplier\', null, null, true)',
+             method='post',
+             action='/votemultiplier', _class='iform')">
+  <table>
+    <tr>
+      <th>
+        <label for="multiplier">${_("Vote multiplier")}</label>
+      </th>
+      <td>
+        <input type="hidden" name="username" id="username"
+               value="${thing.username}"/>
+        <input type="number" min="0" step="1"
+               name="multiplier"
+               size="40"
+               id="multiplier"
+               value="${thing.vote_multiplier}"/>
+      </td>
+      <td>${error_field("NO_AMOUNT", "span")}
+        ${error_field("AMOUNT_NOT_NUM", "span")}
+        ${error_field("AMOUNT_NEGATIVE", "span")}</td>
+    </tr>
+    %if thing.captcha:
+      ${thing.captcha.render()}
+    %endif
+    <tr>
+      <th>
+        <label for="submit"></label>
+      </th>
+      <td>
+        <button id="submit" name="submit" type="submit">${_("Submit")}</button>
+        <span id='status' class='error'></span>
+      </td>
+    </tr>
+  </table>
+</%call>


### PR DESCRIPTION
Admins can assign users a vote multiplier. The default value is 1. It must be an integer >= 0.

Vote multiplier effects future votes, but not past votes.
If it is not 1, a user's vote multiplier shows up on their user page. All users can see everyone else's vote multiplier.

If a user has a multiplier of 0 they can still vote, but their votes do not award any karma. (let me know if you want me to change this)

There is one known issue where if your vote multiplier is changed and you go back to view an old comment which you voted on, it will appear as if the old vote includes the multiplier even though it doesn't. Re-voting and then reloading the page solves the issue. Since this is just a minor UX issue with a non-trivial fix, I don't think we should worry about it. We can always fix it later if we want to.