### PR TITLE
Fix article edit form.

### DIFF
--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -180,7 +180,7 @@
         setMessage(form.title, ${json(_('Enter a title.'))});
         setMessage(form.tags, ${json(_('Enter tags separated by commas or spaces.'))});
 
-        %if thing.tabs.has_tab('article-field-pane'):
+        %if thing.tabs.has_tab('link-field-pane') and not thing.editing:
           setMessage(form.url, ${json(_('Enter a url.'))});
         %endif
 


### PR DESCRIPTION
Fixes #585 

Right now, it's impossible to edit articles. A JavaScript error is thrown when the page loads, preventing the form's onsubmit handler from loading.

As a result, the 'submit' button posts to /submit (which does not exist) instead of making an xhr post to /api/submit.
