### PR TITLE
Install 'acl' to make modern Ansible work

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -8,6 +8,7 @@
     - name: Install ansible dependencies
       apt: name={{ item }} state=present
       with_items:
+        - 'acl'
         - 'git'
         - 'python-psycopg2'
 


### PR DESCRIPTION
This fixes an error where Ansible's temp files aren't accessible when you `become` another user:

See here: https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user