### PR TITLE
mobile-style: improve mobile display

### DIFF
--- a/r2/r2/public/static/lesswrong.css
+++ b/r2/r2/public/static/lesswrong.css
@@ -582,3 +582,85 @@ div.meta.meetup strong {
   -khtml-border-radius: 4px;
   border-radius: 4px;
 }
+
+/* Mobile version.  This overrides styles for small screens, and so needs to stay at the
+   end of the CSS. */
+@media only screen and (max-width: 750px)  {
+    #header { zoom: 0.75 }
+    #sidebar {
+        width: auto;
+        float: none;
+    }
+    #side-search {
+        display: none;
+    }
+    ul#rightnav {
+        margin-top: 15px;
+    }
+    #side-login label {
+        width: 150px;
+    }
+    #side-login #recover {
+        float: none;
+        margin-left: 30px;
+    }
+    #wrapper {
+        width: 750px;
+    }
+    #content .post .post-body h2 {
+        padding-left: 34px;
+    }
+    #content .post .post-body .content .md {
+        font-size: 32px;
+    }
+    #content .post .post-body {
+        margin-left: 5px;
+        margin-right: 5px;
+    }
+    #content .list .meta .votes {
+        margin-top: 4px;
+    }
+    #content .list h2 {
+        padding-left: 10px;
+    }
+    #content {
+        width: 690px;
+        word-wrap: break-word;
+    }
+    .md { font-size: 32px; }
+    .md h2 { font-size: 36px; }
+    .md h3 { font-size: 34px; }
+    .md h4 { font-size: 32px; }
+    ul#nav li {
+        font-size: 20px;
+    }
+    div.post div.postedby {
+        font-size: 24px;
+        line-height: 26px;
+    }
+    #content .post .post-body .post-comment-count a {
+        font-size: 24px;
+    }
+    div.footer {
+        font-size: 18px;
+    }
+    div.comment-meta span {
+        font-size: 32px;
+    }
+    #wrapper {
+        font-size: 20px;
+    }
+    #comments {
+        margin-left: 5px;
+    }
+    #comments h2 {
+        font-size: 28px;
+    }
+    #comment-controls div.filter-inactive, #comment-controls div.filter-active {
+        font-size: 18px;
+    }
+    .comment-links {
+        zoom: 2;
+    }
+    html * {max-height:1000000px;}
+}

--- a/r2/r2/templates/base.html
+++ b/r2/r2/templates/base.html
@@ -30,6 +30,12 @@
   <head>
     <title>${self.Title()}</title>
     
+<!-- `meta name="viewport"` controls how mobile browsers show the page. The page layout is
+originally a desktop layout, built around a screen that is at least 1024px wide.  For
+mobile, we tell the page to display at 750px, lop of the sidebars, then boost the sizes of
+many elements that would otherwise be too small. See the media query at the end of
+lesswrong.css. -->
+    <meta name="viewport" content="width=750">
     <meta name="keywords" content="${self.keywords()}" />
     <meta name="title" content="${self.Title()}" />
     <% description = hasattr(thing, 'link') and thing.link._meta_description() %>


### PR DESCRIPTION
Improve mobile display by switching to a fixed 750px viewport and making things bigger to compensate.  This change is adapted from https://github.com/tricycle/eaforum/pull/65, which took the same approach to the EA Forum.

You can see it live on http://www.jefftk.com/lw-testing/index

Here are some screenshots:

http://www.jefftk.com/lw-testing/comments-old.png
http://www.jefftk.com/lw-testing/comments-new.png

http://www.jefftk.com/lw-testing/discussion-old-top.png
http://www.jefftk.com/lw-testing/discussion-new-top.png

http://www.jefftk.com/lw-testing/discussion-old-bottom.png
http://www.jefftk.com/lw-testing/discussion-new-bottom.png

http://www.jefftk.com/lw-testing/post-old-top.png
http://www.jefftk.com/lw-testing/post-new-top.png

http://www.jefftk.com/lw-testing/promoted-old.png
http://www.jefftk.com/lw-testing/promoted-new.png