### PR TITLE
Fix padding for vote icons.

### DIFF
--- a/r2/r2/public/static/main.css
+++ b/r2/r2/public/static/main.css
@@ -401,7 +401,7 @@ div.meta span.votes span.votes {
 	height: 18px;
 	line-height: 18px;
 	margin: 0;
-	padding: 0 7px;
+	padding: 2px 7px 0;
 	font-weight: bold;
 	text-align: center;
 }
@@ -411,7 +411,7 @@ div.editors-pick div.meta span.votes span.votes {
         border: none;
 	height: 22px;
 	line-height: 22px;
-	padding: 0 9px;
+	padding: 2px 9px 0;
 }
 div.meta span.editors-pick {
 	color: #538d4d;


### PR DESCRIPTION
This makes votes have correct spacing around their numbers:

![screenshot from 2016-12-05 16-43-03](https://cloud.githubusercontent.com/assets/1447206/20903607/ef2e7448-bb09-11e6-8068-3ee60f3ab933.png)
